### PR TITLE
order by multiple fields

### DIFF
--- a/json_to_sql/__init__.py
+++ b/json_to_sql/__init__.py
@@ -1,23 +1,33 @@
 from typing import TYPE_CHECKING, List, Union, Any
 import sqlalchemy as sa
-from sqlalchemy.orm import Session
-from sqlalchemy import desc
 from json_to_sql.schemas import deserialize_filters
 
 if TYPE_CHECKING:
     from json_to_sql.schemas import FilterSchema
 
 def build_query(
-    class_:type,
+    class_: type,
     filters: List['FilterSchema'],
-    property_map:Union[dict, None]=None,
-    order_by:Union[str, None]=None,
-    is_desc:bool=False
+    property_map: Union[dict, None] = None,
+    order_by: Union[str, List[str], None] = None,
+    is_desc: Union[bool, List[bool]] = False
 ):
     _filters = deserialize_filters(filters)
     query = sa.select(class_)
     for f in _filters:
         query = f.apply(query, class_, property_map)
-    if order_by is not None:
-        query = query.order_by(desc(order_by) if is_desc else order_by)
+
+    if isinstance(order_by, str):
+        order_by = [order_by]
+
+    if isinstance(is_desc, bool):
+        is_desc = [is_desc] * (len(order_by) if order_by else 0)
+
+    if order_by:
+        if len(order_by) != len(is_desc):
+            raise ValueError("order_by and is_desc must have the same length.")
+        
+        for field, desc_flag in zip(order_by, is_desc):
+            query = query.order_by(sa.desc(field) if desc_flag else field)
+
     return query

--- a/json_to_sql/__init__.py
+++ b/json_to_sql/__init__.py
@@ -19,12 +19,10 @@ def build_query(
 
     if isinstance(order_by, str):
         order_by = order_by.split(',')
-
-        if property_map:
-            order_by = [
-                getattr(class_, property_map.get(field, field))
-                for field in order_by
-            ]
+        order_by = [
+            getattr(class_, property_map[field] if property_map and field in property_map else field)
+            for field in order_by
+        ]
 
     if isinstance(is_desc, bool):
         is_desc = [is_desc] * (len(order_by) if order_by else 0)

--- a/json_to_sql/__init__.py
+++ b/json_to_sql/__init__.py
@@ -18,7 +18,13 @@ def build_query(
         query = f.apply(query, class_, property_map)
 
     if isinstance(order_by, str):
-        order_by = [order_by]
+        order_by = order_by.split(',')
+
+        if property_map:
+            order_by = [
+                getattr(class_, property_map.get(field, field))
+                for field in order_by
+            ]
 
     if isinstance(is_desc, bool):
         is_desc = [is_desc] * (len(order_by) if order_by else 0)

--- a/json_to_sql/filters/filters.py
+++ b/json_to_sql/filters/filters.py
@@ -46,7 +46,7 @@ def already_joined(stmt:Select, class_:Any):
     collector = TableCollector()
     collector.traverse(stmt)
     
-    tablename = inspect(class_).mapped_table.name
+    tablename = inspect(class_).persist_selectable.name
     return tablename in collector.tables    
     
 class Filter(abc.ABC):

--- a/tests/test_ordered_search.py
+++ b/tests/test_ordered_search.py
@@ -14,7 +14,7 @@ def test_no_filter_no_order(sqlserver_session_factory, dogs):
 def test_no_filter_order_by_name(sqlserver_session_factory:Session, dogs):
     session = sqlserver_session_factory()
     filters = []
-    stmt = json_to_sql.build_query(Dog, filters, order_by=Dog.name)
+    stmt = json_to_sql.build_query(Dog, filters, order_by=[Dog.name])
     results = session.scalars(stmt).all()
     expected_order = [2, 4, 5, 3, 1]    
     assert expected_order == [dog.id for dog in results]
@@ -30,7 +30,7 @@ def test_no_filter_order_by_name_as_string(sqlserver_session_factory:Session, do
 def test_no_filter_order_by_weight(sqlserver_session_factory:Session, dogs):
     session = sqlserver_session_factory()
     filters = []
-    stmt = json_to_sql.build_query(Dog, filters, order_by=Dog.weight)
+    stmt = json_to_sql.build_query(Dog, filters, order_by=[Dog.weight])
     results = session.scalars(stmt).all()
     expected_order = [2, 5, 4, 3, 1]
     assert expected_order == [dog.id for dog in results]
@@ -41,4 +41,12 @@ def test_no_filter_order_by_weight_as_string(sqlserver_session_factory:Session, 
     stmt = json_to_sql.build_query(Dog, filters, order_by="weight")
     results = session.scalars(stmt).all()
     expected_order = [2, 5, 4, 3, 1]
+    assert expected_order == [dog.id for dog in results]
+
+def test_no_filter_order_by_name_and_weight(sqlserver_session_factory:Session, dogs):
+    session = sqlserver_session_factory()
+    filters = []
+    stmt = json_to_sql.build_query(Dog, filters, order_by=[Dog.name, Dog.weight])
+    results = session.scalars(stmt).all()
+    expected_order = [2, 4, 5, 3, 1]    
     assert expected_order == [dog.id for dog in results]

--- a/tests/test_ordered_search.py
+++ b/tests/test_ordered_search.py
@@ -50,3 +50,11 @@ def test_no_filter_order_by_name_and_weight(sqlserver_session_factory:Session, d
     results = session.scalars(stmt).all()
     expected_order = [2, 4, 5, 3, 1]    
     assert expected_order == [dog.id for dog in results]
+
+def test_no_filter_order_by_name_and_weight_as_string(sqlserver_session_factory:Session, dogs):
+    session = sqlserver_session_factory()
+    filters = []
+    stmt = json_to_sql.build_query(Dog, filters, order_by='name,weight')
+    results = session.scalars(stmt).all()
+    expected_order = [2, 4, 5, 3, 1]    
+    assert expected_order == [dog.id for dog in results]


### PR DESCRIPTION
order_by accepting multiple fields (comma separated list or multiple query parameters) + optional is_desc (multiple query parameters). Fixed warning caused by deprecated function. Fixed some tests + added new for the latter functionality.